### PR TITLE
Properly handle renamed devices

### DIFF
--- a/src/delegates/utils/get-device.ts
+++ b/src/delegates/utils/get-device.ts
@@ -41,7 +41,7 @@ export const getDevice = (
     return undefined;
   }
 
-  device.name = hassDevice.name ?? 'Device';
+  device.name = hassDevice.name_by_user ?? hassDevice.name ?? 'Device';
   device.model = [
     hassDevice.manufacturer,
     hassDevice.model,
@@ -54,7 +54,7 @@ export const getDevice = (
     hass,
     config,
     hassDevice.id,
-    hassDevice.name,
+    device.name,
   );
 
   entities.forEach((entity) => {


### PR DESCRIPTION
## Description

User may rename device - `name_by_user` prop should be used.

## Type of change

- [x] Bug fix

## Testing

- [x] Tested on Home Assistant version: latest
- [x] Tested on browser(s): latest FF
